### PR TITLE
Re-add RT60 energy graph, code cleanup

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,5 +1,4 @@
 import librosa
-import audiodata
 import numpy as np
 from scipy.signal import welch, butter, sosfilt, fftconvolve
 

--- a/analysis.py
+++ b/analysis.py
@@ -26,16 +26,21 @@ def bandpass_filter(audio_samples, lowcut, highcut, sampling_rate, order=4):
     sos = butter(order, [low, high], btype='bandpass', output="sos")  # Design a Butterworth bandpass filter.
     return sosfilt(sos, audio_samples)  # Apply the filter to the input signal.
 
-def compute_rt60_band(audio_samples, sampling_rate):
-    """Compute RT60 using the Schroeder method for a given band."""
+def compute_energy_band(filtered_samples):
+    """Compute energy in decibels using the Schroeder method for a given band."""
     # Create a Room Impulse Response (simplified for this demo)
-    rir = fftconvolve(audio_samples, audio_samples[::-1], mode='full')  # Autocorrelation of the signal. (calculation of the RIR value)
+    rir = fftconvolve(filtered_samples, filtered_samples[::-1], mode='full')  # Autocorrelation of the signal. (calculation of the RIR value)
     rir = rir / np.max(np.abs(rir))  # Normalize to avoid overflow. (calculation so the minimum value is one)
 
     energy = (np.square(rir[::-1]))[::-1].cumsum()[::-1]  # defines the decay curve of the audio using schroeder's method (cumulative sum of the RIR array in reverse)
     energy = np.maximum(energy, 1e-10)  # Avoid zero values by setting a floor at 1e - 10
 
     energy_db = 10 * np.log10(np.maximum(energy / np.max(energy), 1e-10))  # Convert energy to dB scale.
+
+    return energy_db
+
+def compute_rt60_band(energy_db, sampling_rate):
+    """Compute RT60 using the Schroeder method for a given band."""
 
     # Find the indices for -5 dB and -65 dB points
     try:
@@ -47,8 +52,8 @@ def compute_rt60_band(audio_samples, sampling_rate):
 
     return rt60
 
-def compute_rt60(data):
-    """Compute RT60 for low, mid, and high frequency bands."""
+def compute_bands(data):
+    """Apply bandpass filters to data for low, mid, and high frequency bands."""
     # Define frequency bands (in Hz)
     low_band = (20, 250)
     mid_band = (250, 2000)
@@ -59,13 +64,27 @@ def compute_rt60(data):
     mid_filtered = bandpass_filter(data._audio_samples, mid_band[0], mid_band[1], data._sampling_rate)
     high_filtered = bandpass_filter(data._audio_samples, high_band[0], high_band[1], data._sampling_rate)
 
+    return low_filtered, mid_filtered, high_filtered
+
+def compute_energy(low_filtered, mid_filtered, high_filtered, sampling_rate):
+    """Compute energy in decibels for low, mid, and high frequency bands."""
+
     # Compute RT60 for each band
-    rt60_low = compute_rt60_band(low_filtered, data._sampling_rate)
-    rt60_mid = compute_rt60_band(mid_filtered, data._sampling_rate)
-    rt60_high = compute_rt60_band(high_filtered, data._sampling_rate)
+    energy_low = compute_energy_band(low_filtered)
+    energy_mid = compute_energy_band(mid_filtered)
+    energy_high = compute_energy_band(high_filtered)
+
+    return energy_low, energy_mid, energy_high
+
+def compute_rt60(energy_low, energy_mid, energy_high, sampling_rate):
+    """Compute RT60 for low, mid, and high frequency bands using energy."""
+
+    # Compute RT60 for each band
+    rt60_low = compute_rt60_band(energy_low, sampling_rate)
+    rt60_mid = compute_rt60_band(energy_mid, sampling_rate)
+    rt60_high = compute_rt60_band(energy_high, sampling_rate)
 
     return rt60_low, rt60_mid, rt60_high
-
 
 def get_resonance(data):
     frequencies, power = welch(data._audio_samples, data._sampling_rate, nperseg=4096)

--- a/audiodata.py
+++ b/audiodata.py
@@ -9,5 +9,12 @@ class AudioData:
         # Perform analysis and store results
         self._audio_duration = analysis.get_duration(self)
         self._audio_resonance = analysis.get_resonance(self)
-        self._rt60 = analysis.compute_rt60(self)
+
+        low_filtered, mid_filtered, high_filtered = analysis.compute_bands(self)
+        energy_low, energy_mid, energy_high = analysis.compute_energy(low_filtered, mid_filtered, high_filtered, _sampling_rate)
+        rt60_low, rt60_mid, rt60_high = analysis.compute_rt60(energy_low, energy_mid, energy_high, _sampling_rate)
+
+        self._filtered = (low_filtered, mid_filtered, high_filtered)
+        self._energy = (energy_low, energy_mid, energy_high)
+        self._rt60 = (rt60_low, rt60_mid, rt60_high)
         pass

--- a/loading.py
+++ b/loading.py
@@ -4,7 +4,6 @@ import sys
 import librosa
 import soundfile as sf
 from audiodata import *
-import shutil
 
 # Returns 3 values:
 # (bool) Success: Returns true if the file was successfully loaded, false if there was an error


### PR DESCRIPTION
Not sure if we are going to add this yet?

This PR reintroduces the RT60 debug graph, only displaying the energy in decibels. It also cleans up the code to remove the temporary analysis code from interface.py and makes the RT60 analysis code more modular.

This should count for the RT60 graph extra credit part of the assignment